### PR TITLE
Prevent Invalid Env Vars

### DIFF
--- a/iis/iis.go
+++ b/iis/iis.go
@@ -352,6 +352,9 @@ func applyAppPoolEnvVars(appPoolName string, envVars map[string]string) error {
 	properties := []string{"set", "config", "-section:system.applicationHost/applicationPools"}
 
 	for key, val := range envVars {
+		if key == "" {
+			continue
+		}
 		if keyExists, isSameValue := doesAppPoolEnvVarExistWithSameValue(appPool, key, val); keyExists {
 			// Delete altered env vars so that they can updated for the Application Pool
 			if isSameValue {

--- a/iis/iis_test.go
+++ b/iis/iis_test.go
@@ -297,6 +297,7 @@ func TestWebsite(t *testing.T) {
 		Env: map[string]string{
 			"EXAMPLE_ENV_VAR":     "test123",
 			"EXAMPLE_ENV_VAR_ALT": "test123",
+			"": "INVALID",
 		},
 		AppPoolIdentity: iisAppPoolIdentity{
 			Identity: "SpecificUser",


### PR DESCRIPTION
Empty strings are an invalid env var key for IIS, so we will ensure that any empty string keys passed in are skipped.

Nomad was passing in an empty string key as part of the task's env vars, probably from a bad template in the job spec.

fix #40 