### PR TITLE
1.0 Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ A `resource_port` OR a `port` must be provided. Due to a current limitation, we 
 | :---: | :---: | :---: | :---: | :---: | :--- |
 | **hostname** | string | no | nil | 7.0 | HostName attribute for a given binding. |
 | **ipaddress** | string | no | * | 7.0 | IPAddress attribute for a given binding. |
-| **resource_port** | string | no | nil | 7.0 | Tie a `resources`->`network` port label to the binding. This allows us to use a dynamic port given by Nomad. |
-| **port** | number | no | 0 | 7.0 | Port attribute for a given binding. This will overwrite `resource_port` settings. |
+| **port** | string | yes | 0 | 7.0 | Tie a `resources`->`network` port label to the binding. This allows us to use a dynamic port given by Nomad. |
 | **type** | string | yes | nil | 7.0 | Type is the binding's protocol e.g. ('http', 'https', etc..) |
 | **cert_hash** | string | no | nil | 7.0 | Hash of a cert that exists prior to nomad allocating an IIS website. This **must** be set for SSL bindings. |
 For more info on IIS Bindings, you can go [here](https://docs.microsoft.com/en-us/iis/configuration/system.applicationhost/sites/site/bindings/binding)

--- a/examples/iis-test-classic.nomad
+++ b/examples/iis-test-classic.nomad
@@ -17,7 +17,7 @@ job "iis-test-classic" {
         path = "C:\\inetpub\\wwwroot"
         bindings {
           type = "http"
-          resource_port = "httplabel"
+          port = "httplabel"
         }
       }
 

--- a/examples/iis-test.nomad
+++ b/examples/iis-test.nomad
@@ -23,7 +23,7 @@ job "iis-test" {
         path = "C:\\inetpub\\wwwroot"
         bindings {
           type = "http"
-          resource_port = "httplabel"
+          port = "httplabel"
         }
       }
 

--- a/iis/driver.go
+++ b/iis/driver.go
@@ -84,12 +84,11 @@ var (
 		"apppool_config_path": hclspec.NewAttr("apppool_config_path", "string", false),
 		"apppool_identity":    hclspec.NewAttr("apppool_identity", "string", false),
 		"bindings": hclspec.NewBlockList("bindings", hclspec.NewObject(map[string]*hclspec.Spec{
-			"hostname":      hclspec.NewAttr("hostname", "string", false),
-			"ipaddress":     hclspec.NewAttr("ipaddress", "string", false),
-			"resource_port": hclspec.NewAttr("resource_port", "string", false),
-			"port":          hclspec.NewAttr("port", "number", false),
-			"type":          hclspec.NewAttr("type", "string", true),
-			"cert_hash":     hclspec.NewAttr("cert_hash", "string", false),
+			"hostname":  hclspec.NewAttr("hostname", "string", false),
+			"ipaddress": hclspec.NewAttr("ipaddress", "string", false),
+			"port":      hclspec.NewAttr("port", "string", true),
+			"type":      hclspec.NewAttr("type", "string", true),
+			"cert_hash": hclspec.NewAttr("cert_hash", "string", false),
 		})),
 	})
 

--- a/iis/iis.go
+++ b/iis/iis.go
@@ -138,12 +138,12 @@ type iisAppPoolIdentity struct {
 
 // IIS Binding struct to match
 type iisBinding struct {
-	CertHash     string `codec:"cert_hash"`
-	HostName     string `codec:"hostname"`
-	IPAddress    string `codec:"ipaddress"`
-	Port         int    `codec:"port"`
-	ResourcePort string `codec:"resource_port"`
-	Type         string `codec:"type"`
+	CertHash  string `codec:"cert_hash"`
+	HostName  string `codec:"hostname"`
+	IPAddress string `codec:"ipaddress"`
+	Port      int
+	PortLabel string `codec:"port"`
+	Type      string `codec:"type"`
 }
 
 // Stat fields that are unmarshalled from WMI


### PR DESCRIPTION
This introduces the check for group level network configs so that the recommended job spec with networking on Nomad v1.0+ works. There is also backwards compatibility functionality for the deprecated network ports, however you can not / should not mix and match between deprecated configs and recommended ones. The 1st party docker driver implements bindings in a similar way.

Removed `resource_port` as a config and migrated the functionality to `port` as a setting. This keeps it on a similar page as other drivers and should help folks understand what needs to be set and not be confused about the `port` number config (which we now rely on Nomad providing that for us).

Fix #43 
