### PR TITLE
fix: update CLA signature bot workflow

### DIFF
--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -11,7 +11,7 @@ jobs:
     if: contains(github.event.comment.html_url, '/pull/') || github.event_name != 'issue_comment'
     steps:
     - name: "CLA Signature Bot"
-      uses: roblox/cla-signature-bot@v2.0.1
+      uses: roblox/cla-signature-bot@v2.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -6,18 +6,10 @@ on:
     types: [opened,closed,synchronize]
  
 jobs:
-  clabot:
-    runs-on: ubuntu-latest
-    if: contains(github.event.comment.html_url, '/pull/') || github.event_name != 'issue_comment'
-    steps:
-    - name: "CLA Signature Bot"
-      uses: roblox/cla-signature-bot@v2.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        whitelist: "shishir-a412ed,chuckyz,vulfox,cliffchapmanrbx"
-        use-remote-repo: true
-        remote-repo-name: "roblox/cla-bot-store"
-        remote-repo-pat: ${{ secrets.CLA_REMOTE_REPO_PAT }}
-        url-to-cladocument: "https://roblox.github.io/cla-bot-store/"
-        
+  call-clabot-workflow:
+    uses: Roblox/cla-signature-bot/.github/workflows/clabot-workflow.yml@master
+    with:
+      whitelist: "shishir-a412ed,chuckyz,vulfox,cliffchapmanrbx"
+      use-remote-repo: true
+      remote-repo-name: "roblox/cla-bot-store"
+    secrets: inherit


### PR DESCRIPTION
This updates the CLA signature bot workflow to leverage a [reusable workflow in the CLA bot repository](https://github.com/Roblox/cla-signature-bot/blob/master/.github/workflows/clabot-workflow.yml). This allows for the signature bot to be updated without needing additional changes to this repository.

The cla bot repository also received an update that addresses the issue where external users would get mentioned if Github cannot find an account to associate with a contributing user. These changes are incorporated in the reusable workflow.

**Note:** Using a reusable workflow changes the check name in this repository. The existing required check needs to be updated to the new check name before merging. Once this PR is merged, the impacted pull request mentioning external users will be re-opened to ensure that the issue has been addressed. 